### PR TITLE
Add flakeDirectory option and update references

### DIFF
--- a/modules/nixos/common/system/os/environment/variables.nix
+++ b/modules/nixos/common/system/os/environment/variables.nix
@@ -4,7 +4,7 @@ in {
   # variables that I want to set globally on all systems
   config = {
     environment.variables = {
-      FLAKE = "/home/${sys.mainUser}/.config/dots";
+      FLAKE = sys.flakeDirectory;
       SSH_AUTH_SOCK = "/run/user/\${UID}/keyring/ssh";
 
       # editors

--- a/modules/options/system/default.nix
+++ b/modules/options/system/default.nix
@@ -50,6 +50,19 @@ in {
   };
 
   options.modules.system = {
+
+    flakeDirectory = mkOption {
+      type = types.enum config.modules.system.users;
+      default = "/home/${config.modules.system.users}/.config/dots";
+      description = ''
+        The directory used for the Nix flakes of the system.
+
+        Ensure that this directory is properly set to avoid issues with Nix flake management and operations. If not set correctly, you may encounter errors when attempting to use Nix flakes or during system operations that depend on them.
+
+        Consider setting {option}`config.modules.system.flakeDirectory` in your configuration to ensure proper flake management.
+      '';
+    };
+
     mainUser = mkOption {
       type = types.enum config.modules.system.users;
       default = builtins.elemAt config.modules.system.users 0;


### PR DESCRIPTION
A new option, flakeDirectory, has been added to the system defaults for the Nix system. This option allows the user to set the directory for storing Nix flakes. References to the previous hard-coded flake path have been updated to use this new flakeDirectory option. The flake.lock file has also been updated.